### PR TITLE
fix: remove '123' from the title of OSS Friends page

### DIFF
--- a/src/pages/oss-friends.astro
+++ b/src/pages/oss-friends.astro
@@ -14,7 +14,7 @@ const friends = body.data.filter(
   <div class="mx-auto max-w-5xl px-6 lg:px-8">
     <div class="mx-auto max-w-2xl text-center">
       <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-        Our Open Source Friends 123
+        Our Open Source Friends
       </h1>
       <p class="mt-2 text-lg leading-6 text-gray-600">
         Here are some of our favorites open-source projects.


### PR DESCRIPTION
Hey guys, just saw this '123' and thought it got there by accident. : )

<img width="1279" height="529" alt="image" src="https://github.com/user-attachments/assets/15f857e3-8a35-4f5a-8e4d-89c23080ffb6" />
